### PR TITLE
feat: mark jecs as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
       "typescript": "=5.5.3",
       "prettier": "^3.2.5"
    },
-   "dependencies": {
+   "peerDependencies": {
       "@rbxts/jecs": "^0.9.0-rc.7"
    }
 }


### PR DESCRIPTION
Proper way to represent the `@rbxts/jecs` package because you can't use Replecs without using Jecs in your project. Didn't update `package-lock.json` but doesn't seem like that's being updated.