### PR TITLE
Add support for blobs when using a custom ser/de

### DIFF
--- a/src/client.luau
+++ b/src/client.luau
@@ -86,7 +86,20 @@ local function read_component_value(client: Client, c: Cursor, variants: { any }
 		local bytespan = client.shared.bytespan[component] or cursor.read_vlq(c)
 
 		local appended = cursor.read_buffer(c, bytespan)
-		local output = serdes.deserialize(appended)
+		local blobs
+
+		if serdes.includes_blobs then
+			local size = cursor.read_vlq(c)
+
+			if size > 0 then
+				local variant_id = cursor.read_vlq(c)
+				blobs = table.move(variants :: { any }, variant_id, variant_id + size - 1, 1, {})
+			else 
+				blobs = {}
+			end
+		end
+
+		local output = serdes.deserialize(appended, blobs)
 		return component, output
 	else
 		local variant_id = cursor.read_vlq(c)

--- a/src/common.luau
+++ b/src/common.luau
@@ -5,8 +5,9 @@ export type PlayerFilter = {
 }
 
 export type Serdes = {
-	serialize: (value: any) -> buffer,
-	deserialize: (buffer) -> any,
+	includes_blobs: boolean?,
+	serialize: (value: any) -> (buffer, { any }?),
+	deserialize: (buffer, { any }?) -> any,
 }
 
 export type Components = {

--- a/src/server.luau
+++ b/src/server.luau
@@ -342,8 +342,31 @@ end
 local function write_component_value(server: Server, c: Cursor, component: Entity, value: any, variants: { any })
 	local serdes = server.shared.serdes[component]
 	if serdes then
-		local output = serdes.serialize(if value == NIL_COMPONENT_VALUE then nil else value)
+		local output, blobs = serdes.serialize(if value == NIL_COMPONENT_VALUE then nil else value)
 
+		if serdes.includes_blobs then
+			if blobs == nil then
+				utils.logerror(
+					"serdes: blobs is equal to nil yet includes_blobs is set to true for component",
+					utils.logcomponent(server.world, component)
+				)
+				-- this will never return (as it just errored above), but Luau's type system needs it.
+				return
+			end
+
+			if #blobs > 0 then
+				cursor.write_vlq(c, #variants + 1)
+				table.move(blobs, 1, #blobs, #variants + 1, variants)
+			end
+
+			cursor.write_vlq(c, #blobs)
+		elseif blobs ~= nil then
+			utils.logerror(
+				"serdes: serializer provided blobs yet includes_blobs is not set to true for component",
+				utils.logcomponent(server.world, component)
+			)
+		end
+		
 		local bytespan = server.shared.bytespan[component]
 		cursor.write_buffer(c, output)
 		if bytespan then


### PR DESCRIPTION
Allows you to serialise something such as:
```ts
interface Test {
  a: string;
  b: string;
  c: Instance;
}
```
Without needing to have it all serialised by Roblox!