### PR TITLE
Fix MemberFilter to allow empty objects

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ declare namespace Replecs {
       };
 
   type MemberFilterMap = Map<Player, boolean>;
-  type MemberFilter = Player | MemberFilterMap | undefined;
+  type MemberFilter = Player | MemberFilterMap | Record<string, never> | undefined;
   type Member = unknown;
 
   export interface SharedInfo<T> {


### PR DESCRIPTION
This change updates the MemberFilter TypeScript definition to allow for an empty object (`Record<string, never>`) to be accepted, which signifies replication to nobody.