### PR TITLE
Fix relation and unreliable markers added before init not being processed properly

### DIFF
--- a/src/server.luau
+++ b/src/server.luau
@@ -207,7 +207,11 @@ local function HOOK_PAIR_REMOVED(world: World, pair_id: Entity, callback: (Entit
 	end)
 end
 
-local function QUERY_TRACKING_TYPE(server: Server, track_type: Component)
+local function QUERY_TRACKING_TYPE(
+	server: Server,
+	track_type: Component,
+	set_tracking_type: (Server, Entity, Component, AnyFilter?) -> ()
+)
 	local world = server.world
 	for entity in world:query(PAIR(track_type, WILDCARD)):iter() do
 		local index = 0
@@ -216,7 +220,7 @@ local function QUERY_TRACKING_TYPE(server: Server, track_type: Component)
 			if not target then
 				break
 			end
-			server.set_reliable(server, entity, target, WORLD_GET(world, entity, PAIR(track_type, target)))
+			set_tracking_type(server, entity, target, WORLD_GET(world, entity, PAIR(track_type, target)))
 			index += 1
 		end
 	end
@@ -228,9 +232,9 @@ local function QUERY_CURRENT_NETWORKED(server: Server)
 	end
 
 	if RELATIONSHIPS then
-		QUERY_TRACKING_TYPE(server, server.components.reliable)
-		QUERY_TRACKING_TYPE(server, server.components.unreliable)
-		QUERY_TRACKING_TYPE(server, server.components.relation)
+		QUERY_TRACKING_TYPE(server, server.components.reliable, server.set_reliable)
+		QUERY_TRACKING_TYPE(server, server.components.unreliable, server.set_unreliable)
+		QUERY_TRACKING_TYPE(server, server.components.relation, server.set_relation)
 	end
 end
 

--- a/tests/replecs.spec.luau
+++ b/tests/replecs.spec.luau
@@ -1980,6 +1980,73 @@ TEST("server -> client replication", function()
 			CHECK(client_tag(member, entity1, 3) == true)
 		end
 	end)
+	CASE("should discover relation markers present before init", function()
+		create_test_components(world)
+		local tags = create_test_tags(world)
+
+		local entity = world:entity()
+		world:add(entity, replecs.Networked)
+		world:add(entity, jecs.pair(replecs.Relation, tags[1]))
+
+		server:init()
+
+		local members = create_members_data(1)
+		activate_members(members)
+		init_member_clients(members)
+
+		local target = world:entity()
+		server:set_networked(target)
+
+		for _, member in members do
+			local buf, variants = server:get_full(member :: any)
+			member.client:apply_full(buf, variants)
+		end
+
+		world:add(entity, jecs.pair(tags[1], target))
+
+		for player, buf, changes in server:collect_updates() do
+			local member: MemberData = player :: any
+			member.client:apply_updates(buf, changes)
+			CHECK(client_relation(member, entity, 1, target) == true)
+			CHECK(client_tag(member, entity, 1) == false)
+		end
+	end)
+	CASE("should discover unreliable markers present before init", function()
+		local components = create_test_components(world)
+		create_test_tags(world)
+
+		local entity = world:entity()
+		world:add(entity, replecs.Networked)
+		world:add(entity, jecs.pair(replecs.Unreliable, components[1]))
+
+		server:init()
+
+		local members = create_members_data(1)
+		activate_members(members)
+		init_member_clients(members)
+
+		for _, member in members do
+			local buf, variants = server:get_full(member :: any)
+			member.client:apply_full(buf, variants)
+		end
+		for player, buf, changes in server:collect_updates() do
+			local member: MemberData = player :: any
+			member.client:apply_updates(buf, changes)
+		end
+		for _, member in members do
+			local client_entity_id = client_entity(member, entity) :: jecs.Entity
+			member.world:add(client_entity_id, member.components[1])
+		end
+
+		world:set(entity, components[1], "unreliable")
+
+		for player, buf, changes in server:collect_unreliable() do
+			local member: MemberData = player :: any
+			member.client:apply_unreliable(buf, changes)
+		end
+
+		CHECK(client_component(members[1], entity, 1) == "unreliable")
+	end)
 	CASE("should send relation changes", function()
 		create_test_components(world)
 		local tags = create_test_tags(world)


### PR DESCRIPTION
Was causing a race condition in my game, with some entities occasionally being created before init is called

This resulted in pairs becoming tags when replicated to the client.

I didn't test the unreliable fix out in the wild but added a test case for it, as well as for the relation, both of which fail before my change, and pass after it.